### PR TITLE
fix(auth): allow users to delete own drafts

### DIFF
--- a/label_studio/core/api_permissions.py
+++ b/label_studio/core/api_permissions.py
@@ -57,6 +57,23 @@ class AnnotationsPermission(BasePermission):
         return False
 
 
+class AnnotationDraftPermission(AnnotationsPermission):
+    def has_object_permission(self, request, view, obj):
+        if request.method != 'DELETE':
+            return super().has_object_permission(request, view, obj)
+
+        if request.user.is_reset_super_user:
+            return True
+
+        return obj.user_id == request.user.id and obj.has_permission(request.user)
+
+    def has_permission(self, request, view):
+        if request.method == 'DELETE':
+            return True
+
+        return super().has_permission(request, view)
+
+
 class SuperUserPermission(BasePermission):
     def has_object_permission(self, request, view, obj):
         if ( request.method

--- a/label_studio/tasks/api.py
+++ b/label_studio/tasks/api.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from core.api_permissions import AnnotationsPermission
+from core.api_permissions import AnnotationDraftPermission, AnnotationsPermission
 from core.feature_flags import flag_set
 from core.mixins import GetParentObjectMixin
 from core.permissions import ViewClassPermission, all_permissions
@@ -23,8 +23,8 @@ from projects.functions.stream_history import fill_history_annotation
 from projects.models import Project
 from rest_framework import generics, viewsets
 from rest_framework.exceptions import PermissionDenied, ValidationError
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from tasks.models import Annotation, AnnotationDraft, Prediction, Task
 from tasks.openapi_schema import (
@@ -894,7 +894,12 @@ class AnnotationDraftAPI(generics.RetrieveUpdateDestroyAPIView):
         PATCH=all_permissions.annotations_change,
         DELETE=all_permissions.annotations_delete,
     )
-    permission_classes = (IsAuthenticated, AnnotationsPermission)
+    permission_classes = (IsAuthenticated, AnnotationDraftPermission)
+
+    def perform_destroy(self, draft):
+        if not self.request.user.is_reset_super_user and draft.user_id != self.request.user.id:
+            raise PermissionDenied('You can only delete your own drafts.')
+        draft.delete()
 
 
 @method_decorator(

--- a/label_studio/tests/test_annotations.py
+++ b/label_studio/tests/test_annotations.py
@@ -7,7 +7,7 @@ import requests_mock
 from django.apps import apps
 from django.urls import reverse
 from projects.models import Project
-from tasks.models import Annotation, Task
+from tasks.models import Annotation, AnnotationDraft, Task
 
 from .utils import _client_is_annotator, invite_client_to_project
 
@@ -123,13 +123,51 @@ def test_create_annotation_with_ground_truth(caplog, any_client, configured_proj
 
 
 @pytest.mark.django_db
-def test_delete_annotation(business_client, configured_project):
+def test_delete_annotation(monkeypatch, business_client, configured_project):
+    monkeypatch.setenv('RESET_SUPERUSERS', business_client.user.email)
     task = Task.objects.first()
     annotation = Annotation.objects.create(task=task, project=configured_project, result=[])
     assert task.annotations.count() == 1
     r = business_client.delete('/api/annotations/{}/'.format(annotation.id))
     assert r.status_code == 204
     assert task.annotations.count() == 0
+
+
+@pytest.mark.django_db
+def test_delete_own_draft_does_not_require_superuser(monkeypatch, business_client, configured_project):
+    monkeypatch.delenv('RESET_SUPERUSERS', raising=False)
+    task = Task.objects.first()
+    draft = AnnotationDraft.objects.create(task=task, user=business_client.user, result=[])
+
+    r = business_client.delete(f'/api/drafts/{draft.id}/')
+
+    assert r.status_code == 204
+    assert not AnnotationDraft.objects.filter(id=draft.id).exists()
+
+
+@pytest.mark.django_db
+def test_delete_other_users_draft_is_forbidden(monkeypatch, business_client, annotator_client, configured_project):
+    monkeypatch.delenv('RESET_SUPERUSERS', raising=False)
+    task = Task.objects.first()
+    configured_project.add_collaborator(annotator_client.user)
+    draft = AnnotationDraft.objects.create(task=task, user=annotator_client.user, result=[])
+
+    r = business_client.delete(f'/api/drafts/{draft.id}/')
+
+    assert r.status_code == 403
+    assert AnnotationDraft.objects.filter(id=draft.id).exists()
+
+
+@pytest.mark.django_db
+def test_delete_annotation_still_requires_superuser(monkeypatch, business_client, configured_project):
+    monkeypatch.delenv('RESET_SUPERUSERS', raising=False)
+    task = Task.objects.first()
+    annotation = Annotation.objects.create(task=task, project=configured_project, result=[])
+
+    r = business_client.delete(f'/api/annotations/{annotation.id}/')
+
+    assert r.status_code == 403
+    assert Annotation.objects.filter(id=annotation.id).exists()
 
 
 @pytest.fixture
@@ -216,7 +254,10 @@ def test_accuracy(
 
 
 @pytest.mark.django_db
-def test_accuracy_on_delete(business_client, annotator_client, project_with_max_annotations_2, annotations):
+def test_accuracy_on_delete(
+    monkeypatch, business_client, annotator_client, project_with_max_annotations_2, annotations
+):
+    monkeypatch.setenv('RESET_SUPERUSERS', business_client.user.email)
     task_id = next(iter(annotations.values()))['task']
     task = Task.objects.get(id=task_id)
     invite_client_to_project(annotator_client, task.project)


### PR DESCRIPTION
## Summary
- allow the draft detail endpoint to delete a user's own draft without reset-superuser privileges
- keep submitted annotation deletion and bulk annotation deletion superuser-only
- add regression coverage for own-draft delete, other-user draft rejection, and submitted annotation rejection

## Verification
- `uv run --no-sync --with ruff==0.8.6 ruff check label_studio/core/api_permissions.py label_studio/tasks/api.py label_studio/tests/test_annotations.py`
- `DJANGO_DB=sqlite uv run --no-sync --with pytest==7.2.2 --with pytest-django==4.9.0 --with pytest-mock==3.14.0 --with pytest-env==0.6.2 --with requests-mock==1.12.1 --with mock==5.1.0 --with freezegun==1.5.1 --with factory-boy==3.3.3 --with moto==4.2.14 --with responses==0.13.0 --with fakeredis==2.26.2 --with psutil==7.0.0 python -m pytest -q label_studio/tests/test_annotations.py`

Default Postgres test mode was attempted but local PostgreSQL was not listening on localhost:5432 in this environment, so it failed during Django test database setup before test execution.