### PR TITLE
fix(auth): allow direct links across member orgs

### DIFF
--- a/label_studio/data_manager/managers.py
+++ b/label_studio/data_manager/managers.py
@@ -892,7 +892,10 @@ class TaskManager(models.Manager):
         return TaskQuerySet(self.model, using=self._db)
 
     def for_user(self, user):
-        return self.get_queryset().filter(project__organization=user.active_organization)
+        return self.get_queryset().filter(
+            project__organization__organizationmember__user=user,
+            project__organization__organizationmember__deleted_at__isnull=True,
+        ).distinct()
 
     def with_state(self):
         """Return queryset with FSM state annotated."""

--- a/label_studio/projects/api.py
+++ b/label_studio/projects/api.py
@@ -529,9 +529,14 @@ class ProjectAPI(generics.RetrieveUpdateDestroyAPIView):
         serializer = GetFieldsSerializer(data=self.request.query_params)
         serializer.is_valid(raise_exception=True)
         fields = serializer.validated_data.get('include')
-        projects = Project.objects.with_counts(fields=fields).filter(
-            organization=self.request.user.active_organization, members__user=self.request.user
-        )
+        if self.request.method in ('GET', 'HEAD', 'OPTIONS'):
+            queryset = Project.objects.for_user(self.request.user)
+        else:
+            queryset = Project.objects.filter(
+                organization=self.request.user.active_organization,
+                members__user=self.request.user,
+            )
+        projects = ProjectManager.with_counts_annotate(queryset, fields=fields)
 
         # Only annotate FSM state for UI/API consumption when both feature flags are enabled
         if flag_set('fflag_feat_fit_568_finite_state_management', user=self.request.user) and flag_set(
@@ -1010,7 +1015,7 @@ class ProjectModelVersions(generics.RetrieveAPIView):
     permission_required = all_permissions.projects_view
 
     def get_queryset(self):
-        return Project.objects.filter(organization=self.request.user.active_organization)
+        return Project.objects.for_user(self.request.user)
 
     def get(self, request, *args, **kwargs):
         project = self.get_object()

--- a/label_studio/projects/mixins.py
+++ b/label_studio/projects/mixins.py
@@ -73,10 +73,10 @@ class ProjectMixin:
 
     def has_permission(self, user):
         """
-        Dummy stub for has_permission
+        Check whether the user belongs to this project's organization.
         """
         user.project = self  # link for activity log
-        return True
+        return bool(self.organization and self.organization.has_permission(user))
 
     def _can_use_overlap(self):
         """

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -111,7 +111,10 @@ class ProjectManager(models.Manager):
         return ProjectQuerySetWithFSM(self.model, using=self._db)
 
     def for_user(self, user):
-        return self.get_queryset().filter(organization=user.active_organization)
+        return self.get_queryset().filter(
+            organization__organizationmember__user=user,
+            organization__organizationmember__deleted_at__isnull=True,
+        ).distinct()
 
     def with_state(self):
         """

--- a/label_studio/projects/tests/test_api.py
+++ b/label_studio/projects/tests/test_api.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.http import urlencode
+from organizations.tests.factories import OrganizationFactory
 from projects.tests.factories import ProjectFactory
 from rest_framework.test import APIClient, APITestCase
 from tasks.models import Task
@@ -90,3 +91,50 @@ class TestProjectModelVersionsAPI(APITestCase):
         assert response.json()['static'][1]['count'] == 1
         assert response.json()['static'][2]['model_version'] == 'model_1'
         assert response.json()['static'][2]['count'] == 2
+
+
+class TestCrossOrganizationProjectAccessAPI(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.active_organization = OrganizationFactory()
+        cls.link_organization = OrganizationFactory()
+        cls.user = cls.active_organization.created_by
+        cls.user.active_organization = cls.active_organization
+        cls.user.save(update_fields=['active_organization'])
+        cls.link_organization.add_user(cls.user)
+        cls.project = ProjectFactory(organization=cls.link_organization)
+
+    def test_project_detail_uses_organization_membership_not_active_organization(self):
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get(f'/api/projects/{self.project.id}/')
+
+        assert response.status_code == 200
+        assert response.json()['id'] == self.project.id
+
+    def test_project_list_remains_active_organization_scoped(self):
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get('/api/projects/')
+
+        assert response.status_code == 200
+        assert self.project.id not in {project['id'] for project in response.json()['results']}
+
+    def test_project_update_remains_active_organization_scoped(self):
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.patch(f'/api/projects/{self.project.id}/', data={'title': 'changed'}, format='json')
+
+        assert response.status_code == 404
+        self.project.refresh_from_db()
+        assert self.project.title != 'changed'
+
+    def test_project_update_requires_project_membership_inside_active_organization(self):
+        project = ProjectFactory(organization=self.active_organization)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(f'/api/projects/{project.id}/', data={'title': 'changed'}, format='json')
+
+        assert response.status_code == 404
+        project.refresh_from_db()
+        assert project.title != 'changed'

--- a/label_studio/projects/tests/test_soft_delete_manager.py
+++ b/label_studio/projects/tests/test_soft_delete_manager.py
@@ -34,28 +34,32 @@ def test_project_manager_filters_deleted():
 
 
 def test_project_manager_for_user_respects_filter():
-    """for_user applies org scope and soft-delete filter.
+    """for_user applies organization membership and soft-delete filter.
 
-    Purpose: Ensure for_user(user) scopes to user's active org and hides deleted rows.
-    Setup: Two orgs; three projects (active+deleted in org1, active in org2).
+    Purpose: Ensure for_user(user) scopes to user's org memberships and hides deleted rows.
+    Setup: Three orgs; active+deleted in org1, active in member org2, active in non-member org3.
     Actions: Call Project.objects.for_user(user) for org1 user.
-    Validations: Only org1 active project is returned.
+    Validations: Active projects from member orgs are returned, regardless of active org.
     Edge cases: N/A.
     """
     org1 = OrganizationFactory()
     org2 = OrganizationFactory()
+    org3 = OrganizationFactory()
     user = org1.created_by
     user.active_organization = org1
     user.save(update_fields=['active_organization'])
+    org2.add_user(user)
 
     p1 = ProjectFactory(organization=org1, title='org1-active')
     _ = ProjectFactory(organization=org1, title='org1-deleted', deleted_at=p1.created_at)
     _ = ProjectFactory(organization=org2, title='org2-active')
+    _ = ProjectFactory(organization=org3, title='org3-active')
 
     titles = set(Project.objects.for_user(user).values_list('title', flat=True))
     assert 'org1-active' in titles
     assert 'org1-deleted' not in titles
-    assert 'org2-active' not in titles
+    assert 'org2-active' in titles
+    assert 'org3-active' not in titles
 
 
 def test_visible_manager_skips_filter_without_column(monkeypatch):

--- a/label_studio/tasks/api.py
+++ b/label_studio/tasks/api.py
@@ -385,8 +385,12 @@ class TaskAPI(generics.RetrieveUpdateDestroyAPIView):
 
         # First check permissions using a lightweight query
         # select_related('project') avoids extra query when permission check accesses task.project
+        if self.request.method in ('GET', 'HEAD', 'OPTIONS'):
+            lean_queryset = Task.objects.for_user(self.request.user)
+        else:
+            lean_queryset = Task.objects.filter(project__organization=self.request.user.active_organization)
         lean_task = generics.get_object_or_404(
-            Task.objects.filter(project__organization=self.request.user.active_organization).select_related('project'),
+            lean_queryset.select_related('project'),
             pk=task_id,
         )
         self.check_object_permissions(self.request, lean_task)

--- a/label_studio/tasks/models.py
+++ b/label_studio/tasks/models.py
@@ -595,7 +595,10 @@ class AnnotationManager(models.Manager):
         return AnnotationQuerySetWithFSM(self.model, using=self._db)
 
     def for_user(self, user):
-        return self.get_queryset().filter(project__organization=user.active_organization)
+        return self.get_queryset().filter(
+            project__organization__organizationmember__user=user,
+            project__organization__organizationmember__deleted_at__isnull=True,
+        ).distinct()
 
     def with_state(self):
         """Return queryset with FSM state annotated."""

--- a/label_studio/tasks/tests/test_api.py
+++ b/label_studio/tasks/tests/test_api.py
@@ -57,6 +57,46 @@ class TestTaskAPI(APITestCase):
             'unresolved_comment_count': 0,
         }
 
+    def test_get_task_uses_organization_membership_not_active_organization(self):
+        active_organization = OrganizationFactory()
+        user = active_organization.created_by
+        user.active_organization = active_organization
+        user.save(update_fields=['active_organization'])
+        self.organization.add_user(user)
+        task = TaskFactory(project=self.project, data={'text': 'linked task'})
+
+        self.client.force_authenticate(user=user)
+        response = self.client.get(f'/api/tasks/{task.id}/')
+
+        assert response.status_code == 200
+        assert response.json()['id'] == task.id
+
+    def test_patch_task_remains_active_organization_scoped(self):
+        active_organization = OrganizationFactory()
+        user = active_organization.created_by
+        user.active_organization = active_organization
+        user.save(update_fields=['active_organization'])
+        self.organization.add_user(user)
+        task = TaskFactory(project=self.project, data={'text': 'linked task'})
+        payload = {
+            'annotations': [],
+            'predictions': [],
+            'data': {'text': 'changed task'},
+            'meta': {},
+            'created_at': '',
+            'updated_at': '',
+            'updated_by': None,
+            'is_labeled': False,
+            'file_upload': None,
+        }
+
+        self.client.force_authenticate(user=user)
+        response = self.client.patch(f'/api/tasks/{task.id}/', data=payload, format='json')
+
+        assert response.status_code == 404
+        task.refresh_from_db()
+        assert task.data == {'text': 'linked task'}
+
     def test_patch_task(self):
         task = TaskFactory(project=self.project, data={'text': 'test'})
 


### PR DESCRIPTION
## Summary
- make direct project/task access use organization membership instead of the current active organization
- keep project list views active-organization scoped so multi-org users do not see every project at once
- add regression tests for cross-active-org project and task links

## Verification
- `DJANGO_DB=sqlite uv run --no-sync --with pytest==7.2.2 --with pytest-django==4.9.0 --with pytest-mock==3.14.0 --with pytest-env==0.6.2 --with requests-mock==1.12.1 --with mock==5.1.0 --with freezegun==1.5.1 --with factory-boy==3.3.3 --with moto==4.2.14 --with responses==0.13.0 --with fakeredis==2.26.2 --with psutil==7.0.0 python -m pytest -q label_studio/projects/tests/test_soft_delete_manager.py label_studio/projects/tests/test_api.py label_studio/tasks/tests/test_api.py`
- `uv run --no-sync --with ruff==0.8.6 ruff check label_studio/projects/mixins.py label_studio/projects/models.py label_studio/data_manager/managers.py label_studio/tasks/models.py label_studio/tasks/api.py label_studio/projects/tests/test_soft_delete_manager.py label_studio/projects/tests/test_api.py label_studio/tasks/tests/test_api.py`
- `uv run --no-sync python -m compileall -q label_studio/projects/mixins.py label_studio/projects/models.py label_studio/data_manager/managers.py label_studio/tasks/models.py label_studio/tasks/api.py label_studio/projects/api.py label_studio/projects/tests/test_soft_delete_manager.py label_studio/projects/tests/test_api.py label_studio/tasks/tests/test_api.py`

Note: full ruff on `label_studio/projects/api.py` still reports pre-existing import cleanup issues unrelated to this patch, so this PR leaves that file's broader import block untouched.