### PR TITLE
feat(mobile): optimize core labeling workflows

### DIFF
--- a/web/apps/labelstudio/src/components/Form/Form.scss
+++ b/web/apps/labelstudio/src/components/Form/Form.scss
@@ -6,7 +6,7 @@
     display: grid;
     justify-items: stretch;
     justify-content: space-between;
-    grid-template-columns: repeat(var(--column-count, 5), 1fr);
+    grid-template-columns: repeat(var(--column-count, 5), minmax(0, 1fr));
     grid-gap: var(--row-gap, 16px) 12px;
 
     &:not(:first-child) {

--- a/web/apps/labelstudio/src/components/Menubar/Menubar.scss
+++ b/web/apps/labelstudio/src/components/Menubar/Menubar.scss
@@ -106,6 +106,42 @@
     border-radius: 50%;
     background: var(--primary_link);
   }
+
+  @media (width < 640px) {
+    &__trigger {
+      width: 48px;
+      min-width: 48px;
+      max-width: 48px;
+      padding: 0 12px;
+    }
+
+    &__logo,
+    &__hotkeys {
+      display: none;
+    }
+
+    &__context {
+      min-width: 0;
+      padding-left: 12px;
+      gap: 8px;
+    }
+
+    &__context-item {
+      min-width: 0;
+
+      &_left {
+        overflow: hidden;
+      }
+
+      &_right {
+        flex-shrink: 0;
+      }
+    }
+
+    &__user {
+      margin: 0 4px;
+    }
+  }
 }
 
 .newsletter-menu-item {

--- a/web/apps/labelstudio/src/components/OrgSwitcher/OrgSwitcher.scss
+++ b/web/apps/labelstudio/src/components/OrgSwitcher/OrgSwitcher.scss
@@ -7,7 +7,7 @@
   overflow: hidden;
   color: var(--sand_900);
   box-shadow: 0 4px 8px rgb(0 0 0 / 5%);
-  margin-bottom: 0px;
+  margin-bottom: 0;
   max-width: 260px;
   width: max-content;
   min-width: 200px;
@@ -28,6 +28,13 @@
       height: 20px;
       color: var(--sand_600);
     }
+  }
+
+  @media (width < 640px) {
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+    box-sizing: border-box;
   }
 }
 

--- a/web/apps/labelstudio/src/components/SidebarMenu/SidebarMenu.scss
+++ b/web/apps/labelstudio/src/components/SidebarMenu/SidebarMenu.scss
@@ -27,4 +27,34 @@
     overflow: auto;
     padding: 2rem;
   }
+
+  @media (width < 640px) {
+    min-width: 0;
+    max-height: none;
+    flex-direction: column;
+
+    &__navigation {
+      width: 100%;
+      max-width: 100%;
+      flex-shrink: 0;
+      overflow-x: auto;
+      border-bottom: 1px solid var(--color-neutral-border);
+
+      .main-menu {
+        width: max-content;
+        min-width: 100%;
+        flex: none;
+        flex-direction: row;
+        border-right: 0;
+      }
+    }
+
+    &__content {
+      width: 100%;
+      min-width: 0;
+      padding: 16px;
+      box-sizing: border-box;
+      overflow: visible;
+    }
+  }
 }

--- a/web/apps/labelstudio/src/components/UserStatsCard/UserStatsCard.scss
+++ b/web/apps/labelstudio/src/components/UserStatsCard/UserStatsCard.scss
@@ -3,6 +3,7 @@
 
 .user-stats {
   --user-stats-gap: 6px;
+
   background: var(--color-neutral-background);
   border-radius: 6px;
   border: 1px solid var(--color-neutral-border);
@@ -124,12 +125,38 @@
     align-self: stretch;
     margin: 0 4px;
   }
+
+  @media (width < 640px) {
+    min-width: 0;
+
+    &__content {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    &__metric {
+      min-width: 0;
+    }
+
+    &__value {
+      font-size: 13px;
+      white-space: nowrap;
+    }
+
+    &__label {
+      white-space: normal;
+    }
+
+    &__divider {
+      display: none;
+    }
+  }
 }
 
 [data-theme='dark'] {
   .user-stats {
     background: var(--color-neutral-surface);
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 1px 2px rgb(0 0 0 / 30%);
 
     &__title {
       color: var(--color-neutral-content-subtler);

--- a/web/apps/labelstudio/src/pages/CreateProject/Config/Config.scss
+++ b/web/apps/labelstudio/src/pages/CreateProject/Config/Config.scss
@@ -714,6 +714,60 @@ div[class^="App_menu"]>div {
   box-shadow: 0 0 0 1.5px rgba(var(--color-accent-mango-base-raw) / 25%);
 }
 
+@media (width < 640px) {
+  .sidebar-menu__content > .wizard {
+    height: auto;
+    margin: -16px;
+  }
+
+  .wizard > .configure {
+    flex-direction: column;
+
+    > * {
+      width: 100%;
+      flex: none;
+    }
+  }
+
+  .wizard .configure__container {
+    grid-template-columns: minmax(0, 1fr) !important;
+    overflow: visible;
+
+    > div {
+      padding: 16px;
+
+      &:first-child {
+        height: auto;
+        min-height: calc(100vh - var(--header-height));
+      }
+    }
+
+    > :nth-child(2) {
+      height: 600px;
+      min-width: 0;
+
+      > [class*='handle'] {
+        display: none;
+      }
+    }
+  }
+
+  .wizard .configure__preview-container {
+    width: 100%;
+    min-width: 0;
+    height: 600px;
+    padding: 0 16px 16px;
+    box-sizing: border-box;
+    flex: none;
+  }
+
+  .wizard .configure__preview {
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+  }
+}
+
 :global(.CodeMirror-dialog-top) {
   border-bottom-color: var(--color-neutral-border);
   padding: var(--spacing-tight);

--- a/web/apps/labelstudio/src/pages/Organization/PeoplePage/PeopleList.scss
+++ b/web/apps/labelstudio/src/pages/Organization/PeoplePage/PeopleList.scss
@@ -104,4 +104,41 @@
       }
     }
   }
+
+  @media (width < 640px) {
+    min-width: 0;
+
+    &__header {
+      display: none;
+    }
+
+    &__user {
+      display: grid;
+      grid-template-columns: 48px minmax(0, 1fr);
+      padding: 8px 0;
+    }
+
+    &__field {
+      width: auto !important;
+      height: auto;
+      min-width: 0;
+      padding: 3px 10px;
+      overflow-wrap: anywhere;
+
+      &.avatar {
+        grid-row: 1 / span 3;
+        align-items: flex-start;
+        padding-top: 6px;
+      }
+
+      &.name:empty {
+        display: none;
+      }
+
+      &.last-activity {
+        color: var(--color-neutral-content-subtler);
+        font-size: 13px;
+      }
+    }
+  }
 }

--- a/web/apps/labelstudio/src/pages/Organization/PeoplePage/PeoplePage.jsx
+++ b/web/apps/labelstudio/src/pages/Organization/PeoplePage/PeoplePage.jsx
@@ -3,7 +3,6 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { useUpdatePageTitle } from "@humansignal/core";
 import { HeidiTips } from "../../../components/HeidiTips/HeidiTips";
 import { modal } from "../../../components/Modal/Modal";
-import { Space } from "../../../components/Space/Space";
 import { cn } from "../../../utils/bem";
 import { FF_AUTH_TOKENS, FF_LSDV_E_297, isFF } from "../../../utils/feature-flags";
 import "./PeopleInvitation.scss";
@@ -61,12 +60,9 @@ export const PeoplePage = () => {
   return (
     <div className={cn("people").toClassName()}>
       <div className={cn("people").elem("controls").toClassName()}>
-        <Space spread>
-          <Space>
-            <OrgSwitcher />
-          </Space>
-
-          <Space>
+        <div className={cn("people").elem("controls-layout").toClassName()}>
+          <OrgSwitcher />
+          <div className={cn("people").elem("actions").toClassName()}>
             {isFF(FF_AUTH_TOKENS) && (
               <Button look="outlined" onClick={showApiTokenSettingsModal} aria-label="Show API token settings">
                 API Tokens Settings
@@ -79,8 +75,8 @@ export const PeoplePage = () => {
             >
               Add Members
             </Button>
-          </Space>
-        </Space>
+          </div>
+        </div>
       </div>
       <div className={cn("people").elem("content").toClassName()}>
         <PeopleList

--- a/web/apps/labelstudio/src/pages/Organization/PeoplePage/PeoplePage.scss
+++ b/web/apps/labelstudio/src/pages/Organization/PeoplePage/PeoplePage.scss
@@ -3,6 +3,17 @@
     padding: 0 0 1rem;
   }
 
+  &__controls-layout,
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
+  &__controls-layout {
+    justify-content: space-between;
+  }
+
   &__content {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -13,5 +24,23 @@
 
   .heidy-tip {
     max-width: 450px;
+  }
+
+  @media (width < 640px) {
+    &__controls-layout,
+    &__actions {
+      align-items: stretch;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    &__actions .button-ls {
+      width: 100%;
+      min-height: 44px;
+    }
+
+    &__content {
+      grid-template-columns: minmax(0, 1fr);
+    }
   }
 }

--- a/web/apps/labelstudio/src/pages/Projects/Projects.jsx
+++ b/web/apps/labelstudio/src/pages/Projects/Projects.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { useParams as useRouterParams } from "react-router";
 import { Redirect } from "react-router-dom";
-import { Button, Dropdown, Space, Typography } from "@humansignal/ui";
+import { Button, Dropdown } from "@humansignal/ui";
 import { Oneof } from "../../components/Oneof/Oneof";
 import { Spinner } from "../../components/Spinner/Spinner";
 import { ApiContext } from "../../providers/ApiProvider";
@@ -223,7 +223,7 @@ export const ProjectsPage = () => {
                 />
               </div>
 
-              <Space>
+              <div className={cn("projects-page").elem("filters").toClassName()}>
                 <Button
                   look={activeOnly ? "primary" : "outlined"}
                   size="small"
@@ -259,7 +259,7 @@ export const ProjectsPage = () => {
                     {SORT_OPTIONS.find((o) => o.key === sortKey)?.label ?? "Sort"}
                   </Button>
                 </Dropdown.Trigger>
-              </Space>
+              </div>
             </div>
 
             <div className={cn("projects-page").elem("stats").toClassName()}>

--- a/web/apps/labelstudio/src/pages/Projects/Projects.scss
+++ b/web/apps/labelstudio/src/pages/Projects/Projects.scss
@@ -16,7 +16,7 @@
     box-sizing: border-box;
     grid-gap: 16px;
     grid-auto-rows: 1fr;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   &__link {
@@ -53,11 +53,13 @@
       grid-template-columns: repeat(4, 1fr);
     }
   }
+
   @media (width >= 1600px) {
     &__list {
       grid-template-columns: repeat(5, 1fr);
     }
   }
+
   @media (width >= 1900px) {
     &__list {
       grid-template-columns: repeat(6, 1fr);
@@ -94,6 +96,12 @@
   &__search {
     min-width: 220px;
     flex: 1 1 300px;
+  }
+
+  &__filters {
+    display: flex;
+    align-items: center;
+    gap: 8px;
   }
 
   &__search-input {
@@ -171,6 +179,65 @@
     &__stats {
       grid-column: auto;
       grid-row: auto;
+    }
+  }
+
+  @media (width < 640px) {
+    &__header {
+      padding: 12px;
+      margin-bottom: 0;
+    }
+
+    &__toolbar {
+      align-items: stretch;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    &__search {
+      width: 100%;
+      min-width: 0;
+      flex-basis: auto;
+    }
+
+    &__search-input {
+      width: 100%;
+      min-height: 44px;
+      box-sizing: border-box;
+    }
+
+    &__filters {
+      display: grid;
+      grid-template-columns: auto auto minmax(120px, 1fr);
+      width: 100%;
+
+      .button-ls {
+        width: 100%;
+        min-height: 44px;
+      }
+    }
+
+    &__list {
+      grid-template-columns: minmax(0, 1fr);
+      grid-auto-rows: auto;
+      gap: 12px;
+      padding: 12px;
+    }
+
+    &__pages {
+      justify-content: flex-start;
+      overflow-x: auto;
+      padding: 8px 12px;
+    }
+  }
+
+  @media (width < 420px) {
+    &__filters {
+      grid-template-columns: 1fr 1fr;
+
+      > :last-child {
+        grid-column: 1 / -1;
+      }
     }
   }
 }
@@ -406,7 +473,7 @@
   &__progress-fill {
     height: 100%;
     transition: width 0.3s ease-out;
-    background: var(--color-primary, #0077ff);
+    background: var(--color-primary, #07f);
     border-radius: 3px;
 
     &_complete {
@@ -419,6 +486,26 @@
     align-items: center;
     padding: 8px 12px 6px 16px;
     justify-content: space-between;
+  }
+
+  @media (width < 640px) {
+    &__menu .button-ls {
+      min-width: 44px;
+      min-height: 44px;
+      margin: -12px -6px -12px 0;
+      opacity: 1;
+    }
+
+    &__annotation {
+      align-items: flex-start;
+      gap: 8px;
+    }
+
+    &__detail {
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      gap: 6px 8px;
+    }
   }
 
 }

--- a/web/apps/labelstudio/src/pages/Settings/settings.scss
+++ b/web/apps/labelstudio/src/pages/Settings/settings.scss
@@ -170,3 +170,43 @@
     width: 488px;
   }
 }
+
+@media (width < 640px) {
+  .simple-settings,
+  .annotation-settings,
+  .general-settings,
+  .webhook {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .settings-wrapper {
+    width: auto;
+    max-width: 40rem;
+    padding: 16px;
+    box-sizing: border-box;
+  }
+
+  .general-settings {
+    flex-direction: column;
+
+    &__wrapper {
+      width: 100%;
+      min-width: 0;
+    }
+
+    .heidy-tip {
+      margin: 24px 0 0;
+    }
+  }
+
+  .annotation-settings__wrapper {
+    width: auto;
+  }
+
+  .radio-group-ls:not(.radio-group-ls_simple) .radio-group-ls__buttons {
+    height: auto;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-auto-flow: row;
+  }
+}

--- a/web/libs/datamanager/src/components/DataManager/Toolbar/TabPanel.scss
+++ b/web/libs/datamanager/src/components/DataManager/Toolbar/TabPanel.scss
@@ -3,4 +3,24 @@
   padding: 12px 16px;
   background-color: var(--color-neutral-background);
   justify-content: space-between;
+
+  @media (width < 640px) {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    padding: 8px;
+    gap: 12px;
+    box-sizing: border-box;
+    justify-content: flex-start;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+
+    .space-dm {
+      flex-shrink: 0;
+    }
+
+    button {
+      min-height: 44px;
+    }
+  }
 }

--- a/web/libs/editor/src/components/App/App.scss
+++ b/web/libs/editor/src/components/App/App.scss
@@ -30,13 +30,6 @@ body {
   }
 }
 
-@include respond("phone") {
-  .editor {
-    width: 300px;
-    min-width: 300px;
-  }
-}
-
 .wrapper {
   flex: 1;
   display: grid;
@@ -164,4 +157,19 @@ body {
 
 :global(.ant-result-success .ant-result-icon>.anticon) {
   color: var(--color-positive-icon);
+}
+
+@include respond("phone") {
+  .editor {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .wrapper_showingBottomBar {
+    --bottombar-height: 104px;
+  }
+
+  .main-view__annotation {
+    padding: var(--spacing-tight);
+  }
 }

--- a/web/libs/editor/src/components/BottomBar/BottomBar.scss
+++ b/web/libs/editor/src/components/BottomBar/BottomBar.scss
@@ -35,4 +35,23 @@
       }
     }
   }
+
+  @media (width <= 640px) {
+    flex-direction: column;
+
+    &__group {
+      width: 100%;
+      min-width: 0;
+      flex: 0 0 52px;
+
+      &:first-child {
+        overflow-x: auto;
+        overscroll-behavior-x: contain;
+      }
+
+      &:last-child .bottombar__section {
+        flex: 1;
+      }
+    }
+  }
 }

--- a/web/libs/editor/src/components/BottomBar/Controls.scss
+++ b/web/libs/editor/src/components/BottomBar/Controls.scss
@@ -139,6 +139,27 @@
       justify-content: flex-end;
     }
   }
+
+  @media (width <= 640px) {
+    .controls {
+      width: 100%;
+      grid-auto-columns: minmax(0, 1fr);
+      padding: 0 8px;
+
+      > *,
+      &__tooltip-wrapper,
+      &__tooltip-wrapper > * {
+        width: 100%;
+        min-width: 0;
+      }
+
+      .button,
+      .submit {
+        width: 100%;
+        min-width: 0;
+      }
+    }
+  }
 }
 
 .submit-option {


### PR DESCRIPTION
## Summary

- make the project, organization, settings, data-manager, and annotation surfaces responsive on phone widths
- remove the fixed 300px annotation editor and reduce phone-only content padding
- stack annotation actions into two full-width rows while retaining contained horizontal scrolling for the compact navigation controls

## Verification

- production frontend build: passed
- targeted Stylelint across all changed SCSS: passed
- Biome check across changed JSX: completed without errors
- isolated dev6 preview at 320px and 390px using six production-derived tasks
- landscape, square, and portrait media render without document-level horizontal overflow
- preview task integrity: 6 tasks, 0 annotations, 0 drafts

## Rollout note

The current static handler marks numbered CSS chunks immutable even though their filenames are not content-hashed. Purge static/CDN assets when deploying this change so existing browsers receive the rebuilt editor chunk.