### PR TITLE
fix(mobile): prioritize labeling detail view

### DIFF
--- a/web/apps/labelstudio/src/pages/Projects/Projects.scss
+++ b/web/apps/labelstudio/src/pages/Projects/Projects.scss
@@ -490,10 +490,15 @@
 
   @media (width < 640px) {
     &__menu .button-ls {
-      min-width: 44px;
-      min-height: 44px;
-      margin: -12px -6px -12px 0;
+      min-width: 48px;
+      min-height: 48px;
+      margin: -14px -6px -14px 0;
       opacity: 1;
+
+      &__icon {
+        width: 24px;
+        height: 24px;
+      }
     }
 
     &__annotation {

--- a/web/libs/datamanager/src/components/Label/Label.scss
+++ b/web/libs/datamanager/src/components/Label/Label.scss
@@ -113,4 +113,14 @@
     box-sizing: border-box;
     padding-bottom: 50px;
   }
+
+  @media (max-width: 640px) {
+    &__table {
+      display: none;
+    }
+
+    &__lsf-wrapper_mode_explorer {
+      margin-left: 0;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- hide the Data Manager spreadsheet pane while labeling at phone widths
- let the labeling interface use the full mobile viewport
- enlarge project-card overflow actions to a 48px touch target with a 24px icon

## Verification
- `NX_DAEMON=false corepack yarn build`
- compiled CSS contains the mobile table-hiding rule
- `git diff --check`