### PR TITLE
fix(mobile): make project actions touch friendly

### DIFF
--- a/web/apps/labelstudio/src/pages/Projects/Projects.scss
+++ b/web/apps/labelstudio/src/pages/Projects/Projects.scss
@@ -305,17 +305,15 @@
   &__menu {
     margin-left: auto;
     flex-shrink: 0;
+  }
 
-    .button-ls {
-      margin-right: -6px;
-      opacity: 0.4;
+  &__menu-button {
+    margin-right: -6px;
+    opacity: 0.65;
 
-      --button-color: var(--text-color);
-
-      &__icon {
-        width: 16px;
-        height: 16px;
-      }
+    svg {
+      width: 18px;
+      height: 18px;
     }
   }
 
@@ -489,16 +487,24 @@
   }
 
   @media (width < 640px) {
-    &__menu .button-ls {
+    &__menu-button {
+      width: 48px;
       min-width: 48px;
+      height: 48px;
       min-height: 48px;
       margin: -14px -6px -14px 0;
       opacity: 1;
+      touch-action: manipulation;
 
-      &__icon {
+      svg {
         width: 24px;
         height: 24px;
       }
+    }
+
+    &__actions-menu .main-menu__item {
+      min-height: 44px;
+      padding: 10px 12px;
     }
 
     &__annotation {

--- a/web/apps/labelstudio/src/pages/Projects/ProjectsList.jsx
+++ b/web/apps/labelstudio/src/pages/Projects/ProjectsList.jsx
@@ -92,13 +92,19 @@ const ProjectCard = ({ project }) => {
             >
               <Dropdown.Trigger
                 content={
-                  <Menu contextual>
+                  <Menu contextual className={cn("project-card").elem("actions-menu").toClassName()}>
                     <Menu.Item href={`/projects/${project.id}/settings`}>Settings</Menu.Item>
                     <Menu.Item href={`/projects/${project.id}/data?labeling=1`}>Label</Menu.Item>
                   </Menu>
                 }
               >
-                <Button size="smaller" look="string" aria-label="Project options">
+                <Button
+                  className={cn("project-card").elem("menu-button").toClassName()}
+                  size="small"
+                  look="outlined"
+                  variant="neutral"
+                  aria-label="Project actions"
+                >
                   <IconEllipsis />
                 </Button>
               </Dropdown.Trigger>


### PR DESCRIPTION
Fixes the project-card action trigger after the UI button migration.

- target the CSS-module Button via a stable project-card class
- use a visible neutral outlined action button
- provide a 48px mobile trigger with a 24px icon
- provide 44px touch targets for Settings and Label menu rows

Verified with the production frontend build.