### PR TITLE
fix(mobile): fit editor actions at phone width

### DIFF
--- a/web/libs/editor/src/components/BottomBar/BottomBar.scss
+++ b/web/libs/editor/src/components/BottomBar/BottomBar.scss
@@ -36,7 +36,7 @@
     }
   }
 
-  @media (width <= 640px) {
+  @media (width <= 760px) {
     flex-direction: column;
 
     &__group {

--- a/web/libs/editor/src/components/BottomBar/Controls.scss
+++ b/web/libs/editor/src/components/BottomBar/Controls.scss
@@ -140,7 +140,7 @@
     }
   }
 
-  @media (width <= 640px) {
+  @media (width <= 760px) {
     .controls {
       width: 100%;
       grid-auto-columns: minmax(0, 1fr);


### PR DESCRIPTION
## Summary
- align the editor bottom bar with the existing 760px phone layout breakpoint
- let Skip and Submit share the available mobile width without horizontal overflow
- leave desktop sizing unchanged

## Validation
- `NX_DAEMON=false corepack yarn build`