### PR TITLE
fix(mobile): make data tasks full screen

### DIFF
--- a/web/libs/datamanager/src/components/Label/Label.scss
+++ b/web/libs/datamanager/src/components/Label/Label.scss
@@ -114,7 +114,7 @@
     padding-bottom: 50px;
   }
 
-  @media (max-width: 640px) {
+  @media (width <= 760px) {
     &__table {
       display: none;
     }


### PR DESCRIPTION
## Summary
- hide the Data Manager spreadsheet across the editor’s full phone breakpoint
- let the task editor use the full width when opened from Data View
- preserve the desktop 50/50 split view
- rely on the existing browser-history entry for native iPhone edge-swipe back

## Validation
- production frontend build
- targeted stylelint and Sass compilation
- Data Manager unit suite: 644 passed
- independent diff review: clean