### PR TITLE
fix(mobile): hide editor panels and refresh assets

### DIFF
--- a/label_studio/core/tests/test_static_serve.py
+++ b/label_studio/core/tests/test_static_serve.py
@@ -1,0 +1,13 @@
+from core.utils.static_serve import static_file_cache_control
+
+
+def test_react_bundle_is_revalidated():
+    assert static_file_cache_control('main.css', 'react-app') == 'no-cache'
+    assert static_file_cache_control('167.css', 'react-app') == 'no-cache'
+
+
+def test_hashed_static_asset_remains_immutable():
+    immutable = 'public, max-age=31536000, immutable'
+
+    assert static_file_cache_control('167.e3d3bc638670f337.css', 'react-app') == immutable
+    assert static_file_cache_control('main.abc12345.css') == immutable

--- a/label_studio/core/utils/static_serve.py
+++ b/label_studio/core/utils/static_serve.py
@@ -5,6 +5,7 @@ during development, and SHOULD NOT be used in a production setting.
 
 import mimetypes
 import posixpath
+import re
 from pathlib import Path
 
 from core.utils.manifest_assets import get_manifest_asset
@@ -17,6 +18,13 @@ from django.utils.http import http_date
 from django.utils.translation import gettext as _
 from django.views.static import was_modified_since
 from ranged_fileresponse import RangedFileResponse
+
+
+def static_file_cache_control(path, manifest_asset_prefix=None):
+    is_hashed_asset = re.search(r'\.[0-9a-f]{8,}\.', path)
+    if manifest_asset_prefix and not is_hashed_asset:
+        return 'no-cache'
+    return 'public, max-age=31536000, immutable'
 
 
 def serve(request, path, document_root=None, show_indexes=False, manifest_asset_prefix=None):
@@ -68,9 +76,9 @@ def serve(request, path, document_root=None, show_indexes=False, manifest_asset_
 
     response = RangedFileResponse(request, fullpath.open('rb'), content_type=content_type)
     response['Last-Modified'] = http_date(statobj.st_mtime)
-    # These assets are served with cache-busting query strings in templates (e.g. `?v=<commit>`),
-    # so allowing long-lived caching significantly improves perceived load time behind proxies.
-    response['Cache-Control'] = 'public, max-age=31536000, immutable'
+    # React entrypoints use cache-busting query strings, but dynamically loaded chunks do not.
+    # Revalidate this bundle so a deployment can never strand clients on stale numbered chunks.
+    response['Cache-Control'] = static_file_cache_control(path, manifest_asset_prefix)
     if encoding:
         response['Content-Encoding'] = encoding
     return response

--- a/web/libs/editor/src/components/SidePanels/SidePanels.scss
+++ b/web/libs/editor/src/components/SidePanels/SidePanels.scss
@@ -132,4 +132,10 @@
       flex: 1;
     }
   }
+
+  @media (width <= 760px) {
+    &__wrapper {
+      display: none;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- remove Regions, History, Relations and Info side-panel chrome on phones
- preserve the existing desktop side panels
- revalidate unhashed React bundles and numbered chunks so mobile CSS updates are not cached for a year
- keep content-hashed assets immutable

## Validation
- production frontend build
- targeted stylelint and Ruff
- cache-policy tests: 2 passed
- compiled CSS contains the <=760px side-panel removal rule
- independent review findings resolved