### PR TITLE
fix(projects): add project member sync endpoint

### DIFF
--- a/label_studio/organizations/api.py
+++ b/label_studio/organizations/api.py
@@ -6,6 +6,7 @@ from core.feature_flags import flag_set
 from core.mixins import GetParentObjectMixin
 from core.utils.common import load_func
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
@@ -18,11 +19,13 @@ from organizations.serializers import (
     OrganizationMemberListParamsSerializer,
     OrganizationMemberListSerializer,
     OrganizationMemberSerializer,
+    OrganizationMemberValidationSerializer,
     OrganizationSerializer,
 )
 from projects.models import Project
 from rest_framework import generics, status
 from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.exceptions import ValidationError as RestValidationError
 from rest_framework.generics import get_object_or_404
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
@@ -31,11 +34,9 @@ from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 from tasks.models import Annotation
-from users.models import User
-from django.contrib.auth import get_user_model
 
-from label_studio.core.permissions import ViewClassPermission, all_permissions
 from label_studio.core.api_permissions import SuperUserInvitePermission
+from label_studio.core.permissions import ViewClassPermission, all_permissions
 from label_studio.core.utils.params import bool_from_request
 
 logger = logging.getLogger(__name__)
@@ -213,6 +214,47 @@ class OrganizationMemberListAPI(generics.ListAPIView):
         page = self.paginated_members   # Using cached property to avoid multiple queries
         serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)
+
+
+@extend_schema(
+    tags=['Organizations'],
+    summary='Validate active organization members',
+    description='Validate canonical email addresses against active members of the caller active organization.',
+    request=OrganizationMemberValidationSerializer,
+    extensions={
+        'x-fern-sdk-group-name': ['organizations', 'members'],
+        'x-fern-sdk-method-name': 'validate',
+        'x-fern-audiences': ['public'],
+    },
+)
+class OrganizationMemberValidationAPI(generics.GenericAPIView):
+    parser_classes = (JSONParser,)
+    serializer_class = OrganizationMemberValidationSerializer
+    permission_required = all_permissions.organizations_view
+
+    def post(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        emails = serializer.validated_data['emails']
+        organization = request.user.active_organization
+        memberships = OrganizationMember.objects.filter(
+            organization=organization,
+            deleted_at__isnull=True,
+            user__is_active=True,
+            user__email__in=emails,
+        ).select_related('user')
+        users_by_email = {membership.user.email: membership.user for membership in memberships}
+        missing_emails = [email for email in emails if email not in users_by_email]
+        if missing_emails:
+            raise RestValidationError(
+                {
+                    'emails': f'Not active members of organization {organization.title}: {", ".join(missing_emails)}'
+                }
+            )
+
+        return Response(
+            {'members': [{'email': email, 'user_id': users_by_email[email].id} for email in emails]}
+        )
 
 
 @method_decorator(

--- a/label_studio/organizations/serializers.py
+++ b/label_studio/organizations/serializers.py
@@ -40,6 +40,17 @@ class OrganizationMemberListParamsSerializer(serializers.Serializer):
     contributed_to_projects = serializers.BooleanField(required=False, default=False)
 
 
+class OrganizationMemberValidationSerializer(serializers.Serializer):
+    emails = serializers.ListField(child=serializers.EmailField(), allow_empty=False)
+
+    def validate_emails(self, emails):
+        if any(email != email.strip().lower() for email in emails):
+            raise serializers.ValidationError('Emails must be lowercase without surrounding whitespace.')
+        if len(emails) != len(set(emails)):
+            raise serializers.ValidationError('Emails must be unique.')
+        return emails
+
+
 @extend_schema_serializer(
     deprecate_fields=[
         'created_projects',

--- a/label_studio/organizations/tests/test_api.py
+++ b/label_studio/organizations/tests/test_api.py
@@ -125,3 +125,46 @@ class TestOrganizationMemberListAPI(APITestCase):
                 'title': project_2.title,
             }
         ]
+
+
+class TestOrganizationMemberValidationAPI(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.organization = OrganizationFactory()
+        cls.owner = cls.organization.created_by
+        cls.member = UserFactory(email='member@example.com', active_organization=cls.organization)
+        cls.inactive_member = UserFactory(
+            email='inactive@example.com',
+            active_organization=cls.organization,
+            is_active=False,
+        )
+
+    def test_validates_active_members_in_request_order(self):
+        self.client.force_authenticate(user=self.owner)
+
+        response = self.client.post(
+            '/api/organizations/members/validate/',
+            {'emails': [self.member.email, self.owner.email]},
+            format='json',
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            'members': [
+                {'email': self.member.email, 'user_id': self.member.id},
+                {'email': self.owner.email, 'user_id': self.owner.id},
+            ]
+        }
+
+    def test_rejects_missing_or_inactive_members(self):
+        self.client.force_authenticate(user=self.owner)
+
+        response = self.client.post(
+            '/api/organizations/members/validate/',
+            {'emails': ['missing@example.com', self.inactive_member.email]},
+            format='json',
+        )
+
+        assert response.status_code == 400
+        assert 'missing@example.com' in str(response.json())
+        assert self.inactive_member.email in str(response.json())

--- a/label_studio/organizations/urls.py
+++ b/label_studio/organizations/urls.py
@@ -17,6 +17,7 @@ _urlpatterns = [
 _api_urlpattens = [
     # organization list viewset
     path('', api.OrganizationListAPI.as_view(), name='organization-list'),
+    path('members/validate/', api.OrganizationMemberValidationAPI.as_view(), name='organization-members-validate'),
     # organization detail viewset
     path('<int:pk>', api.OrganizationAPI.as_view(), name='organization-detail'),
     # organization memberships list viewset

--- a/label_studio/projects/api.py
+++ b/label_studio/projects/api.py
@@ -1088,8 +1088,8 @@ class ProjectAnnotatorsAPI(generics.RetrieveAPIView):
 
 @extend_schema(
     tags=['Projects'],
-    summary='Enable project members',
-    description='Enable active members of the project organization by canonical email address.',
+    summary='Enable members on projects',
+    description='Atomically enable active organization members on projects by canonical email address.',
     request=ProjectMemberSyncSerializer,
     extensions={
         'x-fern-sdk-group-name': 'projects',
@@ -1109,15 +1109,21 @@ class ProjectMembersAPI(generics.GenericAPIView):
         )
 
     def post(self, request, *args, **kwargs):
-        project = self.get_object()
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+        project_ids = serializer.validated_data['project_ids']
         emails = serializer.validated_data['emails']
 
         with transaction.atomic():
-            project = Project.objects.select_for_update().get(pk=project.pk)
+            projects = list(
+                self.get_queryset().select_for_update().filter(pk__in=project_ids).order_by('pk')
+            )
+            if {project.id for project in projects} != set(project_ids):
+                raise Http404
+
+            organization = projects[0].organization
             organization_members = OrganizationMember.objects.filter(
-                organization=project.organization,
+                organization=organization,
                 deleted_at__isnull=True,
                 user__is_active=True,
                 user__email__in=emails,
@@ -1127,21 +1133,22 @@ class ProjectMembersAPI(generics.GenericAPIView):
             if missing_emails:
                 raise RestValidationError(
                     {
-                        'emails': f'Not active members of organization {project.organization.title}: {", ".join(missing_emails)}'
+                        'emails': f'Not active members of organization {organization.title}: {", ".join(missing_emails)}'
                     }
                 )
 
-            for email in emails:
-                user = users_by_email[email]
-                memberships = ProjectMember.objects.select_for_update().filter(project=project, user=user)
-                if memberships.exists():
-                    memberships.update(enabled=True, updated_at=timezone.now())
-                else:
-                    ProjectMember.objects.create(project=project, user=user, enabled=True)
+            for project in projects:
+                for email in emails:
+                    user = users_by_email[email]
+                    memberships = ProjectMember.objects.select_for_update().filter(project=project, user=user)
+                    if memberships.exists():
+                        memberships.update(enabled=True, updated_at=timezone.now())
+                    else:
+                        ProjectMember.objects.create(project=project, user=user, enabled=True)
 
         return Response(
             {
-                'project_id': project.id,
+                'project_ids': project_ids,
                 'members': [{'email': email, 'user_id': users_by_email[email].id} for email in emails],
             }
         )

--- a/label_studio/projects/api.py
+++ b/label_studio/projects/api.py
@@ -20,7 +20,7 @@ from core.utils.serializer_to_openapi_params import serializer_to_openapi_params
 from data_manager.functions import filters_ordering_selected_items_exist, get_prepared_queryset
 from django.conf import settings
 from django.core.cache import cache
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.db.models import Count, F, Q, Sum
 from django.db.models.functions import TruncDate
 from django.http import Http404
@@ -32,6 +32,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter, OpenApiResponse, extend_schema
 from label_studio_sdk.label_interface.interface import LabelInterface
 from ml.serializers import MLBackendSerializer
+from organizations.models import OrganizationMember
 from projects.functions import (
     annotate_finished_task_number,
     annotate_weekly_annotation_count,
@@ -46,6 +47,7 @@ from projects.serializers import (
     ProjectCountsSerializer,
     ProjectImportSerializer,
     ProjectLabelConfigSerializer,
+    ProjectMemberSyncSerializer,
     ProjectModelVersionExtendedSerializer,
     ProjectModelVersionParamsSerializer,
     ProjectReimportSerializer,
@@ -1082,6 +1084,68 @@ class ProjectAnnotatorsAPI(generics.RetrieveAPIView):
         users = User.objects.filter(id__in=annotator_ids).prefetch_related('om_through').order_by('id')
         data = UserSimpleSerializer(users, many=True, context={'request': request}).data
         return Response(data)
+
+
+@extend_schema(
+    tags=['Projects'],
+    summary='Enable project members',
+    description='Enable active members of the project organization by canonical email address.',
+    request=ProjectMemberSyncSerializer,
+    extensions={
+        'x-fern-sdk-group-name': 'projects',
+        'x-fern-sdk-method-name': 'enable_members',
+        'x-fern-audiences': ['public'],
+    },
+)
+class ProjectMembersAPI(generics.GenericAPIView):
+    parser_classes = (JSONParser,)
+    serializer_class = ProjectMemberSyncSerializer
+    permission_required = all_permissions.projects_change
+
+    def get_queryset(self):
+        return Project.objects.filter(
+            organization=self.request.user.active_organization,
+            members__user=self.request.user,
+        )
+
+    def post(self, request, *args, **kwargs):
+        project = self.get_object()
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        emails = serializer.validated_data['emails']
+
+        with transaction.atomic():
+            project = Project.objects.select_for_update().get(pk=project.pk)
+            organization_members = OrganizationMember.objects.filter(
+                organization=project.organization,
+                deleted_at__isnull=True,
+                user__is_active=True,
+                user__email__in=emails,
+            ).select_related('user')
+            users_by_email = {membership.user.email: membership.user for membership in organization_members}
+            missing_emails = [email for email in emails if email not in users_by_email]
+            if missing_emails:
+                raise RestValidationError(
+                    {
+                        'emails': f'Not active members of organization {project.organization.title}: {", ".join(missing_emails)}'
+                    }
+                )
+
+            for email in emails:
+                user = users_by_email[email]
+                memberships = ProjectMember.objects.select_for_update().filter(project=project, user=user)
+                if memberships.exists():
+                    memberships.update(enabled=True, updated_at=timezone.now())
+                else:
+                    ProjectMember.objects.create(project=project, user=user, enabled=True)
+
+        return Response(
+            {
+                'project_id': project.id,
+                'members': [{'email': email, 'user_id': users_by_email[email].id} for email in emails],
+            }
+        )
+
 
 @extend_schema(
     tags=['Users'],

--- a/label_studio/projects/serializers.py
+++ b/label_studio/projects/serializers.py
@@ -29,6 +29,7 @@ from label_studio_sdk.label_interface.control_tags import (
     TimeSeriesLabelsTag,
     VideoRectangleTag,
 )
+from organizations.serializers import OrganizationMemberValidationSerializer
 from projects.models import Project, ProjectImport, ProjectOnboarding, ProjectReimport, ProjectSummary
 from rest_flex_fields import FlexFieldsModelSerializer
 from rest_framework import serializers
@@ -37,22 +38,13 @@ from tasks.models import Task
 from users.serializers import UserSimpleSerializer
 
 
-class ProjectMemberSyncSerializer(serializers.Serializer):
+class ProjectMemberSyncSerializer(OrganizationMemberValidationSerializer):
     project_ids = serializers.ListField(child=serializers.IntegerField(min_value=1), allow_empty=False)
-    emails = serializers.ListField(child=serializers.EmailField(), allow_empty=False)
 
     def validate_project_ids(self, project_ids):
         if len(project_ids) != len(set(project_ids)):
             raise serializers.ValidationError('Project IDs must be unique.')
         return project_ids
-
-    def validate_emails(self, emails):
-        if any(email != email.strip().lower() for email in emails):
-            raise serializers.ValidationError('Emails must be lowercase without surrounding whitespace.')
-        if len(emails) != len(set(emails)):
-            raise serializers.ValidationError('Emails must be unique.')
-        return emails
-
 
 @extend_schema_field({'type': 'object', 'additionalProperties': True})
 class OpenApiObjectJSONField(serializers.JSONField):

--- a/label_studio/projects/serializers.py
+++ b/label_studio/projects/serializers.py
@@ -38,7 +38,13 @@ from users.serializers import UserSimpleSerializer
 
 
 class ProjectMemberSyncSerializer(serializers.Serializer):
+    project_ids = serializers.ListField(child=serializers.IntegerField(min_value=1), allow_empty=False)
     emails = serializers.ListField(child=serializers.EmailField(), allow_empty=False)
+
+    def validate_project_ids(self, project_ids):
+        if len(project_ids) != len(set(project_ids)):
+            raise serializers.ValidationError('Project IDs must be unique.')
+        return project_ids
 
     def validate_emails(self, emails):
         if any(email != email.strip().lower() for email in emails):

--- a/label_studio/projects/serializers.py
+++ b/label_studio/projects/serializers.py
@@ -37,6 +37,17 @@ from tasks.models import Task
 from users.serializers import UserSimpleSerializer
 
 
+class ProjectMemberSyncSerializer(serializers.Serializer):
+    emails = serializers.ListField(child=serializers.EmailField(), allow_empty=False)
+
+    def validate_emails(self, emails):
+        if any(email != email.strip().lower() for email in emails):
+            raise serializers.ValidationError('Emails must be lowercase without surrounding whitespace.')
+        if len(emails) != len(set(emails)):
+            raise serializers.ValidationError('Emails must be unique.')
+        return emails
+
+
 @extend_schema_field({'type': 'object', 'additionalProperties': True})
 class OpenApiObjectJSONField(serializers.JSONField):
     """

--- a/label_studio/projects/tests/test_api.py
+++ b/label_studio/projects/tests/test_api.py
@@ -220,16 +220,19 @@ class TestProjectMembersAPI(APITestCase):
         cls.owner = cls.organization.created_by
         cls.project = ProjectFactory(organization=cls.organization)
         ProjectMember.objects.create(project=cls.project, user=cls.owner)
+        cls.second_project = ProjectFactory(organization=cls.organization)
+        ProjectMember.objects.create(project=cls.second_project, user=cls.owner)
         cls.member = UserFactory(email='member@example.com', active_organization=cls.organization)
         cls.outsider = UserFactory(email='outsider@example.com')
 
     def get_url(self):
-        return reverse('projects:api:project-members', kwargs={'pk': self.project.id})
+        return reverse('projects:api:project-members')
 
-    def test_enables_active_organization_members_idempotently(self):
+    def test_enables_active_organization_members_on_projects_idempotently(self):
         ProjectMember.objects.create(project=self.project, user=self.member, enabled=False)
         self.client.force_authenticate(user=self.owner)
-        payload = {'emails': [self.owner.email, self.member.email]}
+        project_ids = [self.project.id, self.second_project.id]
+        payload = {'project_ids': project_ids, 'emails': [self.owner.email, self.member.email]}
 
         first_response = self.client.post(self.get_url(), payload, format='json')
         second_response = self.client.post(self.get_url(), payload, format='json')
@@ -237,14 +240,17 @@ class TestProjectMembersAPI(APITestCase):
         assert first_response.status_code == 200
         assert second_response.status_code == 200
         assert first_response.json() == {
-            'project_id': self.project.id,
+            'project_ids': project_ids,
             'members': [
                 {'email': self.owner.email, 'user_id': self.owner.id},
                 {'email': self.member.email, 'user_id': self.member.id},
             ],
         }
-        memberships = ProjectMember.objects.filter(project=self.project, user__in=[self.owner, self.member])
-        assert memberships.count() == 2
+        memberships = ProjectMember.objects.filter(
+            project__in=[self.project, self.second_project],
+            user__in=[self.owner, self.member],
+        )
+        assert memberships.count() == 4
         assert all(membership.enabled for membership in memberships)
 
     def test_rejects_non_members_before_changing_any_membership(self):
@@ -253,7 +259,10 @@ class TestProjectMembersAPI(APITestCase):
 
         response = self.client.post(
             self.get_url(),
-            {'emails': [self.member.email, self.outsider.email]},
+            {
+                'project_ids': [self.project.id, self.second_project.id],
+                'emails': [self.member.email, self.outsider.email],
+            },
             format='json',
         )
 
@@ -263,33 +272,36 @@ class TestProjectMembersAPI(APITestCase):
         assert membership.enabled is False
         assert not ProjectMember.objects.filter(project=self.project, user=self.outsider).exists()
 
-    def test_rejects_duplicate_or_noncanonical_emails(self):
+    def test_rejects_duplicate_projects_or_noncanonical_emails(self):
         self.client.force_authenticate(user=self.owner)
 
-        duplicate_response = self.client.post(
+        duplicate_projects_response = self.client.post(
             self.get_url(),
-            {'emails': [self.member.email, self.member.email]},
+            {'project_ids': [self.project.id, self.project.id], 'emails': [self.member.email]},
             format='json',
         )
         noncanonical_response = self.client.post(
             self.get_url(),
-            {'emails': [self.member.email.upper()]},
+            {'project_ids': [self.project.id], 'emails': [self.member.email.upper()]},
             format='json',
         )
 
-        assert duplicate_response.status_code == 400
+        assert duplicate_projects_response.status_code == 400
         assert noncanonical_response.status_code == 400
 
     def test_rejects_project_outside_active_organization(self):
         other_organization = OrganizationFactory()
         other_project = ProjectFactory(organization=other_organization)
         ProjectMember.objects.create(project=other_project, user=self.owner)
+        membership = ProjectMember.objects.create(project=self.project, user=self.member, enabled=False)
         self.client.force_authenticate(user=self.owner)
 
         response = self.client.post(
-            reverse('projects:api:project-members', kwargs={'pk': other_project.id}),
-            {'emails': [self.owner.email]},
+            self.get_url(),
+            {'project_ids': [self.project.id, other_project.id], 'emails': [self.member.email]},
             format='json',
         )
 
         assert response.status_code == 404
+        membership.refresh_from_db()
+        assert membership.enabled is False

--- a/label_studio/projects/tests/test_api.py
+++ b/label_studio/projects/tests/test_api.py
@@ -12,6 +12,7 @@ from projects.tests.factories import ProjectFactory
 from rest_framework.test import APIClient, APITestCase
 from tasks.models import Annotation, Task
 from tasks.tests.factories import AnnotationFactory, PredictionFactory, TaskFactory
+from users.tests.factories import UserFactory
 
 
 class TestProjectCountsListAPI(TestCase):
@@ -210,3 +211,85 @@ class TestCrossOrganizationProjectAccessAPI(APITestCase):
         assert response.status_code == 404
         project.refresh_from_db()
         assert project.title != 'changed'
+
+
+class TestProjectMembersAPI(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.organization = OrganizationFactory()
+        cls.owner = cls.organization.created_by
+        cls.project = ProjectFactory(organization=cls.organization)
+        ProjectMember.objects.create(project=cls.project, user=cls.owner)
+        cls.member = UserFactory(email='member@example.com', active_organization=cls.organization)
+        cls.outsider = UserFactory(email='outsider@example.com')
+
+    def get_url(self):
+        return reverse('projects:api:project-members', kwargs={'pk': self.project.id})
+
+    def test_enables_active_organization_members_idempotently(self):
+        ProjectMember.objects.create(project=self.project, user=self.member, enabled=False)
+        self.client.force_authenticate(user=self.owner)
+        payload = {'emails': [self.owner.email, self.member.email]}
+
+        first_response = self.client.post(self.get_url(), payload, format='json')
+        second_response = self.client.post(self.get_url(), payload, format='json')
+
+        assert first_response.status_code == 200
+        assert second_response.status_code == 200
+        assert first_response.json() == {
+            'project_id': self.project.id,
+            'members': [
+                {'email': self.owner.email, 'user_id': self.owner.id},
+                {'email': self.member.email, 'user_id': self.member.id},
+            ],
+        }
+        memberships = ProjectMember.objects.filter(project=self.project, user__in=[self.owner, self.member])
+        assert memberships.count() == 2
+        assert all(membership.enabled for membership in memberships)
+
+    def test_rejects_non_members_before_changing_any_membership(self):
+        membership = ProjectMember.objects.create(project=self.project, user=self.member, enabled=False)
+        self.client.force_authenticate(user=self.owner)
+
+        response = self.client.post(
+            self.get_url(),
+            {'emails': [self.member.email, self.outsider.email]},
+            format='json',
+        )
+
+        assert response.status_code == 400
+        assert self.outsider.email in str(response.json())
+        membership.refresh_from_db()
+        assert membership.enabled is False
+        assert not ProjectMember.objects.filter(project=self.project, user=self.outsider).exists()
+
+    def test_rejects_duplicate_or_noncanonical_emails(self):
+        self.client.force_authenticate(user=self.owner)
+
+        duplicate_response = self.client.post(
+            self.get_url(),
+            {'emails': [self.member.email, self.member.email]},
+            format='json',
+        )
+        noncanonical_response = self.client.post(
+            self.get_url(),
+            {'emails': [self.member.email.upper()]},
+            format='json',
+        )
+
+        assert duplicate_response.status_code == 400
+        assert noncanonical_response.status_code == 400
+
+    def test_rejects_project_outside_active_organization(self):
+        other_organization = OrganizationFactory()
+        other_project = ProjectFactory(organization=other_organization)
+        ProjectMember.objects.create(project=other_project, user=self.owner)
+        self.client.force_authenticate(user=self.owner)
+
+        response = self.client.post(
+            reverse('projects:api:project-members', kwargs={'pk': other_project.id}),
+            {'emails': [self.owner.email]},
+            format='json',
+        )
+
+        assert response.status_code == 404

--- a/label_studio/projects/urls.py
+++ b/label_studio/projects/urls.py
@@ -47,8 +47,8 @@ _api_urlpatterns = [
     path('<int:pk>/model-versions/', api.ProjectModelVersions.as_view(), name='project-model-versions'),
     # List all annotators for project
     path('<int:pk>/annotators/', api.ProjectAnnotatorsAPI.as_view(), name='project-annotators'),
-    # Enable active organization members for the project
-    path('<int:pk>/members/', api.ProjectMembersAPI.as_view(), name='project-members'),
+    # Atomically enable active organization members on projects
+    path('members/', api.ProjectMembersAPI.as_view(), name='project-members'),
     # User metrics
     path('user-metrics/', api.UserMetricsAPI.as_view(), name='user-metrics'),
 ]

--- a/label_studio/projects/urls.py
+++ b/label_studio/projects/urls.py
@@ -47,6 +47,8 @@ _api_urlpatterns = [
     path('<int:pk>/model-versions/', api.ProjectModelVersions.as_view(), name='project-model-versions'),
     # List all annotators for project
     path('<int:pk>/annotators/', api.ProjectAnnotatorsAPI.as_view(), name='project-annotators'),
+    # Enable active organization members for the project
+    path('<int:pk>/members/', api.ProjectMembersAPI.as_view(), name='project-members'),
     # User metrics
     path('user-metrics/', api.UserMetricsAPI.as_view(), name='user-metrics'),
 ]


### PR DESCRIPTION
## Summary
- add an authenticated Django endpoint to enable project members by canonical email
- update every requested project in one database transaction
- require users to be active organization members and projects to be visible in the caller active organization
- make membership creation and re-enabling idempotent
- reject empty, duplicate, or non-canonical identifiers before changing memberships

## Tests
- 14 project API tests passed with DJANGO_DB=sqlite
- uv run --with ruff ruff check label_studio/projects/api.py label_studio/projects/serializers.py label_studio/projects/tests/test_api.py label_studio/projects/urls.py